### PR TITLE
feat(number_of_processors): Improve web implementation

### DIFF
--- a/lib/src/number_of_processors/processors_web.dart
+++ b/lib/src/number_of_processors/processors_web.dart
@@ -1,24 +1,17 @@
 import 'dart:html';
+import 'dart:math';
 
-/// Web implementation to get the number of logical processors (CPU cores) available for worker tasks.
-/// Uses the browser's `navigator.hardwareConcurrency` API to determine the count.
+/// Returns the number of available processors for concurrent execution.
 ///
-/// The implementation reserves one core for the main thread by returning
-/// `hardwareConcurrency - 1` when multiple cores are available. This ensures
-/// the main thread has dedicated resources for UI and other critical operations.
-///
-/// Returns:
-///   * Number of logical processors minus 1 if multiple cores are available
-///   * 1 if only a single core is available or if hardwareConcurrency is not supported
-///
-/// This matches the behavior of the IO implementation which also reserves one core
-/// for the main thread.
+/// This function uses the `navigator.hardwareConcurrency` API to determine
+/// the number of available threads. It returns n - 1 threads, where n is
+/// the number of available threads, with one thread reserved for the main
+/// thread to avoid skipping frames.
+
 int get numberOfProcessors {
-  // Check if multiple cores are available and subtract one for the main thread
-  if (window.navigator.hardwareConcurrency != null &&
-      window.navigator.hardwareConcurrency! > 1) {
-    return window.navigator.hardwareConcurrency! - 1;
-  }
-  // Return 1 if single core or API not supported
-  return 1;
+  // Get the hardware concurrency, defaulting to 1 if not available
+  final concurrency = window.navigator.hardwareConcurrency ?? 1;
+
+  // Subtract 1 and ensure the result is at least 1
+  return max(concurrency - 1, 1);
 }


### PR DESCRIPTION
Improve the web implementation of the `numberOfProcessors` function to
better handle edge cases and provide a more reliable count of available
processors. The changes include:

- Use the `dart:math` library to ensure the result is always at least 1
- Simplify the logic by directly subtracting 1 from the hardware
  concurrency value, instead of checking for a specific threshold
- Add a comment to explain the reasoning behind reserving one core for
  the main thread